### PR TITLE
delta/feed error handling

### DIFF
--- a/src/PureClarity/Api/Delta/Base.php
+++ b/src/PureClarity/Api/Delta/Base.php
@@ -164,11 +164,13 @@ abstract class Base
 
         $status = $curl->getStatus();
         $error = $curl->getError();
+        $body = $curl->getBody();
 
         if ($status !== 200) {
             throw new Exception(
-                'Error: HTTP ' . $status . ' Response ' .
-                'Message: ' . $error
+                'Error: HTTP ' . $status . ' Response | ' .
+                'Error Message: ' . $error . ' | ' .
+                'Body: ' . $body
             );
         }
 
@@ -180,7 +182,7 @@ abstract class Base
 
         return [
             'status' => $status,
-            'body' => $curl->getBody()
+            'body' => $body
         ];
     }
 

--- a/src/PureClarity/Api/Delta/Base.php
+++ b/src/PureClarity/Api/Delta/Base.php
@@ -162,10 +162,25 @@ abstract class Base
         $curl = $this->getCurlHandler();
         $curl->post($url, $body);
 
+        $status = $curl->getStatus();
+        $error = $curl->getError();
+
+        if ($status !== 200) {
+            throw new Exception(
+                'Error: HTTP ' . $status . ' Response ' .
+                'Message: ' . $error
+            );
+        }
+
+        if ($error) {
+            throw new Exception(
+                'Error: ' . $error
+            );
+        }
+
         return [
-            'status' => $curl->getStatus(),
-            'body' => $curl->getBody(),
-            'error' => $curl->getError()
+            'status' => $status,
+            'body' => $curl->getBody()
         ];
     }
 

--- a/src/PureClarity/Api/Feed/Transfer.php
+++ b/src/PureClarity/Api/Feed/Transfer.php
@@ -142,11 +142,13 @@ class Transfer
 
         $status = $curl->getStatus();
         $error = $curl->getError();
+        $body = $curl->getBody();
 
         if ($status !== 200) {
             throw new Exception(
-                'Error: HTTP ' . $status . ' Response ' .
-                'Message: ' . $error
+                'Error: HTTP ' . $status . ' Response | ' .
+                'Message: ' . $error . ' | ' .
+                'Body: ' . $body . ' | '
             );
         }
 
@@ -156,7 +158,7 @@ class Transfer
 
         return [
             'status' => $status,
-            'body' => $curl->getBody()
+            'body' => $body
         ];
     }
 

--- a/src/PureClarity/Api/Feed/Transfer.php
+++ b/src/PureClarity/Api/Feed/Transfer.php
@@ -140,14 +140,22 @@ class Transfer
         $curl->setDataType('application/x-www-form-urlencoded');
         $curl->post($url, $request);
 
+        $status = $curl->getStatus();
         $error = $curl->getError();
+
+        if ($status !== 200) {
+            throw new Exception(
+                'Error: HTTP ' . $status . ' Response ' .
+                'Message: ' . $error
+            );
+        }
 
         if (empty($error) === false) {
             throw new Exception($error);
         }
 
         return [
-            'status' => $curl->getStatus(),
+            'status' => $status,
             'body' => $curl->getBody()
         ];
     }

--- a/tests/unit/PureClarity/Api/Delta/Type/ProductTest.php
+++ b/tests/unit/PureClarity/Api/Delta/Type/ProductTest.php
@@ -274,7 +274,7 @@ class ProductTest extends MockeryTestCase
             $this->subject->send();
         } catch (Exception $e) {
             $this->assertEquals(
-                'Error: HTTP 500 Response Message: Some error',
+                'Error: HTTP 500 Response | Error Message: Some error | Body: ',
                 $e->getMessage()
             );
         }
@@ -302,7 +302,7 @@ class ProductTest extends MockeryTestCase
             $this->subject->send();
         } catch (Exception $e) {
             $this->assertEquals(
-                'Error: HTTP 500 Response Message: Some error',
+                'Error: HTTP 500 Response | Error Message: Some error | Body: ',
                 $e->getMessage()
             );
         }
@@ -385,11 +385,9 @@ class ProductTest extends MockeryTestCase
             ->times($pages)
             ->andReturn($error);
 
-        if (empty($error) || $statusCode === 200) {
-            $curl->shouldReceive('getBody')
-                ->times($pages)
-                ->andReturn($response);
-        }
+        $curl->shouldReceive('getBody')
+            ->times($pages)
+            ->andReturn($response);
 
 
 

--- a/tests/unit/PureClarity/Api/Delta/Type/ProductTest.php
+++ b/tests/unit/PureClarity/Api/Delta/Type/ProductTest.php
@@ -235,6 +235,7 @@ class ProductTest extends MockeryTestCase
      */
     public function testInvalidRegion()
     {
+        $error = '';
         try {
             $this->mockEndpoint('Invalid Region supplied');
             $test = new Product(
@@ -245,11 +246,13 @@ class ProductTest extends MockeryTestCase
             $test->addData(['SKU' => 'test123']);
             $test->send();
         } catch (Exception $e) {
-            $this->assertEquals(
-                'Invalid Region supplied',
-                $e->getMessage()
-            );
+            $error = $e->getMessage();
         }
+
+        $this->assertEquals(
+            'Invalid Region supplied',
+            $error
+        );
     }
 
     /**
@@ -269,15 +272,18 @@ class ProductTest extends MockeryTestCase
         $this->mockEndpoint();
         $this->mockCurl($expectedBody, 500, '', 'Some error');
 
+        $error = '';
         try {
             $this->subject->addData(['SKU' => 'test123']);
             $this->subject->send();
         } catch (Exception $e) {
-            $this->assertEquals(
-                'Error: HTTP 500 Response | Error Message: Some error | Body: ',
-                $e->getMessage()
-            );
+            $error = $e->getMessage();
         }
+
+        $this->assertEquals(
+            'Error: HTTP 500 Response | Error Message: Some error | Body: ',
+            $error
+        );
     }
 
     /**
@@ -297,15 +303,23 @@ class ProductTest extends MockeryTestCase
         $this->mockEndpoint();
         $this->mockCurl($expectedBody, 200, 'An error response');
 
+        $error = '';
         try {
             $this->subject->addData(['SKU' => 'test123']);
-            $this->subject->send();
-        } catch (Exception $e) {
+            $response = $this->subject->send();
+
             $this->assertEquals(
-                'Error: HTTP 500 Response | Error Message: Some error | Body: ',
-                $e->getMessage()
+                'An error response',
+                $response[0]['body']
             );
+        } catch (Exception $e) {
+            $error = $e->getMessage();
         }
+
+        $this->assertEquals(
+            '',
+            $error
+        );
     }
 
     /**
@@ -388,8 +402,6 @@ class ProductTest extends MockeryTestCase
         $curl->shouldReceive('getBody')
             ->times($pages)
             ->andReturn($response);
-
-
 
         return $curl;
     }

--- a/tests/unit/PureClarity/Api/Feed/TransferTest.php
+++ b/tests/unit/PureClarity/Api/Feed/TransferTest.php
@@ -193,6 +193,27 @@ class TransferTest extends MockeryTestCase
     }
 
     /**
+     * Tests that an exception is thrown when the Curl returns an error
+     */
+    public function testHttpError()
+    {
+        $this->mockEndpoint();
+        $this->mockCurl('feed-create', '{"Version": 2, "Products":[', '', 400, 'An Error');
+
+        $error = '';
+        try {
+            $this->subject->create('{"Version": 2, "Products":[');
+        } catch (Exception $e) {
+            $error = $e->getMessage();
+        }
+
+        $this->assertEquals(
+            'Error: HTTP 400 Response | Message: An Error | Body:  | ',
+            $error
+        );
+    }
+
+    /**
      * Mocks the Curl class
      *
      * @see \PureClarity\Api\Transfer\Curl
@@ -223,11 +244,9 @@ class TransferTest extends MockeryTestCase
                 ->times(1)
                 ->andReturn($error);
 
-            if (empty($error)) {
-                $client->shouldReceive('getBody')
-                    ->times(1)
-                    ->andReturn($body);
-            }
+            $client->shouldReceive('getBody')
+                ->times(1)
+                ->andReturn($body);
         } else {
             $client->shouldReceive('post')
                 ->with($url, $postBody)

--- a/tests/unit/PureClarity/Api/Feed/TransferTest.php
+++ b/tests/unit/PureClarity/Api/Feed/TransferTest.php
@@ -215,6 +215,10 @@ class TransferTest extends MockeryTestCase
                 ->with($url, $postBody)
                 ->times(1);
 
+            $client->shouldReceive('getStatus')
+                ->times(1)
+                ->andReturn($status);
+
             $client->shouldReceive('getError')
                 ->times(1)
                 ->andReturn($error);
@@ -223,10 +227,6 @@ class TransferTest extends MockeryTestCase
                 $client->shouldReceive('getBody')
                     ->times(1)
                     ->andReturn($body);
-
-                $client->shouldReceive('getStatus')
-                    ->times(1)
-                    ->andReturn($status);
             }
         } else {
             $client->shouldReceive('post')

--- a/tests/unit/PureClarity/Api/Resource/EndpointsTest.php
+++ b/tests/unit/PureClarity/Api/Resource/EndpointsTest.php
@@ -65,6 +65,7 @@ class EndpointsTest extends MockeryTestCase
      */
     public function testInvalidRegion()
     {
+        $error = '';
         try {
             $regions = m::mock('overload:PureClarity\Api\Resource\Regions');
 
@@ -75,11 +76,13 @@ class EndpointsTest extends MockeryTestCase
             
             $this->subject->getDeltaEndpoint('error');
         } catch (Exception $e) {
-            $this->assertEquals(
-                'Invalid Region supplied',
-                $e->getMessage()
-            );
+            $error = $e->getMessage();
         }
+
+        $this->assertEquals(
+            'Invalid Region supplied',
+            $error
+        );
     }
 
     /**


### PR DESCRIPTION
Improvements to delta / feed error handling so that the following are treated as exceptions:

 - non 200 HTTP status code
 - curl errors (e.g. timeout, could not resolve host etc)